### PR TITLE
Added -P flag to specify which OpenCL Platform to look at

### DIFF
--- a/src/libzogminer/gpuconfig.h
+++ b/src/libzogminer/gpuconfig.h
@@ -31,6 +31,7 @@ public:
 	//~GPUConfig();
 	
 	bool useGPU;
+	unsigned platformId;
 	int64_t selGPU;
 	unsigned globalWorkSize;
 	unsigned workgroupSize;

--- a/src/libzogminer/gpusolver.cpp
+++ b/src/libzogminer/gpusolver.cpp
@@ -41,7 +41,7 @@ char *s_hexdump(const void *_a, uint32_t a_len)
 	return buf;
 }
 
-GPUSolver::GPUSolver() {
+GPUSolver::GPUSolver(unsigned platformId) {
 
 	/* Notes
 	I've added some extra parameters in this interface to assist with dev, such as
@@ -72,7 +72,7 @@ GPUSolver::GPUSolver() {
 	@params: unsigned localWorkSizes
 	@params: unsigned globalWorkSizes
 	*/
-	GPU = miner->configureGPU(0, local_work_size, global_work_size);
+	GPU = miner->configureGPU(platformId, local_work_size, global_work_size);
 	if(!GPU)
 		std::cout << "ERROR: No suitable GPU found! No work will be performed!" << std::endl;
 
@@ -86,11 +86,11 @@ GPUSolver::GPUSolver() {
 	std::vector<std::string> kernels {"kernel_init_ht", "kernel_round0", "kernel_round1", "kernel_round2","kernel_round3", "kernel_round4", "kernel_round5", "kernel_round6", "kernel_round7", "kernel_round8", "kernel_sols"};
 
 	if(GPU)
-		initOK = miner->init(0, 0, kernels);
+		initOK = miner->init(platformId, 0, kernels);
 
 }
 
-GPUSolver::GPUSolver(int64_t selGPU) {
+GPUSolver::GPUSolver(unsigned platformId, int64_t selGPU) {
 
 	/* Notes
 	I've added some extra parameters in this interface to assist with dev, such as
@@ -121,7 +121,7 @@ GPUSolver::GPUSolver(int64_t selGPU) {
 	@params: unsigned localWorkSizes
 	@params: unsigned globalWorkSizes
 	*/
-	GPU = miner->configureGPU(0, local_work_size, global_work_size);
+	GPU = miner->configureGPU(platformId, local_work_size, global_work_size);
 	if(!GPU)
 		std::cout << "ERROR: No suitable GPU found! No work will be performed!" << std::endl;
 
@@ -134,7 +134,7 @@ GPUSolver::GPUSolver(int64_t selGPU) {
 	*/
 	std::vector<std::string> kernels {"kernel_init_ht", "kernel_round0", "kernel_round1", "kernel_round2","kernel_round3", "kernel_round4", "kernel_round5", "kernel_round6", "kernel_round7", "kernel_round8", "kernel_sols"};
 	if(GPU)
-		initOK = miner->init(0, selGPU, kernels);
+		initOK = miner->init(platformId, selGPU, kernels);
 
 }
 

--- a/src/libzogminer/gpusolver.h
+++ b/src/libzogminer/gpusolver.h
@@ -64,8 +64,8 @@ enum GPUSolverCancelCheck
 class GPUSolver {
 
 public:
-	GPUSolver();
-	GPUSolver(int64_t selGPU);
+	GPUSolver(unsigned platformId);
+	GPUSolver(unsigned platformId, int64_t selGPU);
 	~GPUSolver();
         bool run(unsigned int n, unsigned int k, uint8_t *header, size_t header_len, uint64_t nonce,
 		            const std::function<bool(std::vector<unsigned char>)> validBlock,

--- a/src/standaloneminer.cpp
+++ b/src/standaloneminer.cpp
@@ -107,7 +107,7 @@ void test_mine(int n, int k, uint32_t d, GPUConfig conf)
     arith_uint256 hashTarget = arith_uint256().SetCompact(d);
 	GPUSolver * solver;
 	if(conf.useGPU)
-    	solver = new GPUSolver(conf.selGPU);
+    	solver = new GPUSolver(conf.platformId, conf.selGPU);
 
 	uint64_t nn= 0;
 	//TODO Free
@@ -246,6 +246,7 @@ int main(int argc, char* argv[])
 
 	conf.useGPU = GetBoolArg("-G", false);
 	conf.selGPU = GetArg("-S", 0);
+	conf.platformId = GetArg("-P", 0);
 	//std::cout << GPU << " " << selGPU << std::endl;
 
     // Zcash debugging


### PR DESCRIPTION
Earlier I had [posted in the forums](https://forum.z.cash/t/zogminer-linux-silentarmy-miner/2152/693?u=lhl) with having an issue where zogminer couldn't find any OpenCL devices to mine with despite -listdevices showing my RX470.

After a bit of poking, and converting the original SILENTARMY to return CL_DEVICE_TYPE_ALL, I realized what was up:

```
Devices on platform "AMD Accelerated Parallel Processing":
  ID 0: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
Devices on platform "AMD Accelerated Parallel Processing":
  ID 1: Ellesmere
  ID 2: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
```

Platform 0 for me is the CPU. So even though zogminer was able to -listdevices properly, it'd always be pointing to the wrong platform, hence erroring out.

I've added an addition `-P` flag that functions similarly to `-S` - defaults to 0 if not used, but allows the end user to select their platform.